### PR TITLE
Use Node 18

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Node ⚙️
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
 
       - name: Install and Build 🔧
         env:

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": false,
   "license": "Apache-2.0",
-  "homepage": "/",
+  "homepage": "/play-thema",
   "dependencies": {
     "@grafana/faro-react": "^1.0.2",
     "@grafana/faro-web-sdk": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": false,
   "license": "Apache-2.0",
-  "homepage": "/play-thema",
+  "homepage": "/",
   "dependencies": {
     "@grafana/faro-react": "^1.0.2",
     "@grafana/faro-web-sdk": "^1.0.2",
@@ -50,5 +50,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "engines": {
+    "node": ">= 18"
   }
 }


### PR DESCRIPTION
With grafana/toolkit gone, it shouldn't be necessary to use Node 16 anymore and we can use the version 18. Also grafana packages from version 9.5 should also be using Node 18. 

I also updated the homepage to `/` to fix the issue with the incorrect encoding of the wasm file when run locally. 