### PR TITLE
Update homepage setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": false,
   "license": "Apache-2.0",
-  "homepage": "/play-thema",
+  "homepage": ".",
   "dependencies": {
     "@grafana/faro-react": "^1.0.2",
     "@grafana/faro-web-sdk": "^1.0.2",


### PR DESCRIPTION
According to the [CRA docs](https://create-react-app.dev/docs/deployment/#serving-the-same-build-from-different-paths), it's be possible to serve the app from different paths by specifying `homepage` as `.`. It works locally, now just need to check if it also works on prod. 