### PR TITLE
Fix header img src

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -16,7 +16,7 @@ const Header = () => {
   return (
     <div className={styles.header}>
       <div className={styles.flex}>
-        <img src={'/grafana.svg'} alt={'Grafana logo'} className={styles.logo} />
+        <img src={`${process.env.PUBLIC_URL}/grafana.svg`} alt={'Grafana logo'} className={styles.logo} />
         <h4 className={styles.headerText}>Thema Playground</h4>
       </div>
       <div className={styles.flex}>


### PR DESCRIPTION
The header image isn't working now in [production](https://grafana.github.io/play-thema), I suspect because of the different `PUBLIC_URL` in production (note the `/play-thema` appended in the URL). See the screenshot below (I tries to fetch it from `
https://grafana.github.io/grafana.svg`):

![image](https://github.com/grafana/play-thema/assets/5459617/b849bd06-cd4e-45bc-a087-b42cf74541db)

So, this pull request changes how the `img.src` is defined to take the `PUBLIC_URL` into consideration.
Any alternative suggestion @Clarity-89?

Thanks!