### PR TITLE
Fix call to WASM function

### DIFF
--- a/src/services/wasm/index.ts
+++ b/src/services/wasm/index.ts
@@ -61,7 +61,7 @@ export const TranslateToLatest = (lineage: string, input: string): void => {
 
 export const TranslateToVersion = (lineage: string, input: string, version: string): void => {
   // @ts-ignore
-  const res = translateToLatest(lineage, input);
+  const res = translateToVersion(lineage, input, version);
   if (res.error !== '') {
     publish({ stderr: `'TranslateToVersion' failed: ${res.error}` });
     return;


### PR DESCRIPTION
It fixes the call from `TranslateToVersion` function to the corresponding one from the WASM artifact, which was wrong (calling `TranslateToLatest`) probably due to some typo or copy & paste error. 